### PR TITLE
finalized markets & market outcomes

### DIFF
--- a/app/css/index.css
+++ b/app/css/index.css
@@ -692,3 +692,10 @@ h3 {
 .invalid-tag {
 	color: #ccc
 }
+
+.market-outcomes ul {
+	list-style-type: disc;
+	padding-left: 1.5rem;
+	margin: 0;
+	padding-inline-start: 20px;
+}

--- a/app/ts/ReportingUI/components/Reporting.tsx
+++ b/app/ts/ReportingUI/components/Reporting.tsx
@@ -370,6 +370,10 @@ export const Reporting = ({ maybeReadClient, maybeWriteClient, universe, reputat
 
 	const finalizeDisabled = useComputed(() => marketData.deepValue?.hotLoadingMarketData.reportingState !== 'AwaitingFinalization')
 	const migrationDisabled = useComputed(() => marketData.deepValue?.hotLoadingMarketData.reportingState !== 'AwaitingForkMigration')
+	const showReporting = useComputed(() => {
+		const state = marketData.deepValue?.hotLoadingMarketData.reportingState
+		return state === 'CrowdsourcingDispute' || state === 'DesignatedReporting' || state === 'OpenReporting' || state === 'AwaitingNextWindow'
+	})
 
 	const getParsedExtraInfo = (extraInfo: string) => {
 		try {
@@ -493,13 +497,14 @@ export const Reporting = ({ maybeReadClient, maybeWriteClient, universe, reputat
 					/>
 					<button class = 'button button-primary' onClick = { refreshData }>Refresh</button>
 				</div>
-			</>}>
-				<ReportingHistory marketData = { marketData } reportingHistory = { reportingHistory } outcomeStakes = { outcomeStakes } forkValues = { forkValues }/>
-				<DisplayStakes outcomeStakes = { outcomeStakes } marketData = { marketData } maybeWriteClient = { maybeWriteClient } preemptiveDisputeCrowdsourcerStake = { preemptiveDisputeCrowdsourcerStake } disputeWindowInfo = { disputeWindowInfo } forkValues = { forkValues } lastCompletedCrowdSourcer = { lastCompletedCrowdSourcer } repBond = { repBond } refreshData = { refreshData }/>
-				{ marketData.deepValue === undefined || finalizeDisabled.value ? <> </> : <button class = 'button button-primary' onClick = { finalizeMarketButton } disabled = { finalizeDisabled }>Finalize Market</button> }
+			</> }>
+				{ showReporting.value === false ? <></> : <>
+					<ReportingHistory marketData = { marketData } reportingHistory = { reportingHistory } outcomeStakes = { outcomeStakes } forkValues = { forkValues }/>
+					<DisplayStakes outcomeStakes = { outcomeStakes } marketData = { marketData } maybeWriteClient = { maybeWriteClient } preemptiveDisputeCrowdsourcerStake = { preemptiveDisputeCrowdsourcerStake } disputeWindowInfo = { disputeWindowInfo } forkValues = { forkValues } lastCompletedCrowdSourcer = { lastCompletedCrowdSourcer } repBond = { repBond } refreshData = { refreshData }/>
+					{ marketData.deepValue === undefined || finalizeDisabled.value ? <> </> : <button class = 'button button-primary' onClick = { finalizeMarketButton } disabled = { finalizeDisabled }>Finalize Market</button> }
+				</> }
 				<ForkMigration marketData = { marketData } maybeWriteClient = { maybeWriteClient } outcomeStakes = { outcomeStakes } disabled = { migrationDisabled } refreshData = { refreshData }/>
 			</Market>
-
 		</div>
 	</div>
 }

--- a/app/ts/utils/augurUtils.ts
+++ b/app/ts/utils/augurUtils.ts
@@ -18,11 +18,15 @@ export const isGenesisUniverse = (universeAddress: AccountAddress | undefined) =
 export const getAllPayoutNumeratorCombinations = (numOutcomes: bigint, numTicks: EthereumQuantity): readonly bigint[][] => Array.from({ length: Number(numOutcomes) }, (_, outcome) => Array.from({ length: Number(numOutcomes) }, (_, index) => index === outcome ? numTicks : 0n))
 
 type MarketType = 'Yes/No' | 'Categorical' | 'Scalar'
-const getYesNoCategoricalOutcomeName = (index: number, marketType: 'Yes/No' | 'Categorical', outcomes: readonly `0x${ string }`[]) => {
+export const getYesNoCategoricalOutcomeName = (index: number, marketType: 'Yes/No' | 'Categorical', outcomes: readonly `0x${ string }`[]) => {
 	if (index === 0) return 'Invalid'
-	if (marketType === 'Yes/No') return YES_NO_OPTIONS[index]
+	if (marketType === 'Yes/No') {
+		const option = YES_NO_OPTIONS[index]
+		if (option === undefined) throw new Error('invalid outcome index')
+		return option
+	}
 	const outcomeName = outcomes[index - 1]
-	if (outcomeName === undefined) return undefined
+	if (outcomeName === undefined) throw new Error('invalid outcome index')
 	return new TextDecoder().decode(stripTrailingZeros(stringToUint8Array(outcomeName)))
 }
 


### PR DESCRIPTION
- show reporting options only when market is reportable (eg, not finished)
- show answer options alongside with market
![image](https://github.com/user-attachments/assets/b1ee58d1-281f-46ed-ab35-0501f0a0d898)
