### PR TITLE
Exact

### DIFF
--- a/solidity/contracts/AugurConstantProductMarketRouter.sol
+++ b/solidity/contracts/AugurConstantProductMarketRouter.sol
@@ -216,7 +216,7 @@ contract AugurConstantProductRouter {
 		noShares = noSharesReceived > completeSetsToSell ? noSharesReceived - completeSetsToSell : 0;
 		yesShares = yesSharesReceived > completeSetsToSell ? yesSharesReceived - completeSetsToSell : 0;
 		if (noShares > 0) noShareTokenWrapper.transfer(msg.sender, noShares);
-		if (yesShares > completeSetsToSell) yesShareTokenWrapper.transfer(msg.sender, yesShares);
+		if (yesShares > 0) yesShareTokenWrapper.transfer(msg.sender, yesShares);
 	}
 
 	function getExpectedAmountsFromLiquidity(address augurMarketAddress, int24 tickLower, int24 tickUpper, uint128 amountNo, uint128 amountYes) external view returns (uint256) {

--- a/solidity/ts/hookSalt.ts
+++ b/solidity/ts/hookSalt.ts
@@ -1,1 +1,1 @@
-export const HOOK_SALT = 53049n
+export const HOOK_SALT = 426922n

--- a/solidity/ts/hookSalt.ts
+++ b/solidity/ts/hookSalt.ts
@@ -1,1 +1,1 @@
-export const HOOK_SALT = 287809n
+export const HOOK_SALT = 24402n

--- a/solidity/ts/hookSalt.ts
+++ b/solidity/ts/hookSalt.ts
@@ -1,1 +1,1 @@
-export const HOOK_SALT = 24402n
+export const HOOK_SALT = 53049n

--- a/solidity/ts/hookSalt.ts
+++ b/solidity/ts/hookSalt.ts
@@ -1,1 +1,1 @@
-export const HOOK_SALT = 242981n
+export const HOOK_SALT = 287809n

--- a/solidity/ts/tests/test.ts
+++ b/solidity/ts/tests/test.ts
@@ -688,7 +688,7 @@ describe('Contract Test Suite', () => {
 		const finalShareBalances = await getShareBalances(liquidityProviderClient2, liquidityProviderClient2.account.address)
 		assert.strictEqual(finalShareBalances[0], 0n, `User received excess Invalid shares incorrectly`)
 		assert.strictEqual(finalShareBalances[1], 1n, `User received excess No shares incorrectly`)
-		assert.strictEqual(finalShareBalances[2], 0n, `User received Yes shares incorrectly`)
+		assert.strictEqual(finalShareBalances[2], 3n, `User received Yes shares incorrectly`)
 	})
 
 	test('canOnlyWithdrawProfitUpToInitialEntry', async () => {

--- a/solidity/ts/tests/test.ts
+++ b/solidity/ts/tests/test.ts
@@ -2,7 +2,7 @@ import { describe, beforeEach, test } from 'node:test'
 import { getMockedEthSimulateWindowEthereum, MockWindowEthereum } from '../testsuite/simulator/MockWindowEthereum.js'
 import { createWriteClient } from '../testsuite/simulator/utils/viem.js'
 import { SHARE_TOKEN, TEST_ADDRESSES, UNIV4_MAX_TICK, UNIV4_MIN_TICK, UNIV4_POOL_MANAGER, UNIV4_POSITION_MANAGER, YEAR_2030 } from '../testsuite/simulator/utils/constants.js'
-import { deployAugurConstantProductMarket, approveCash, getCashAllowance, setERC1155Approval, setupTestAccounts, getAugurConstantProductMarketRouterAddress, getMarketAddress, getPoolLiquidityBalance, getCashBalance, mintLiquidity, getNextPositionManagerToken, getExpectedLiquidity, getShareBalances, decreaseLiquidity, getReportingFee, burnLiquidity, increaseLiquidity, expectedSharesAfterSwap, enterPosition, expectedSharesNeededForSwap, exitPosition, swapExactIn, swapExactOut, getNumMarkets, getMarkets, getLpTokens, getMarketIsValid, unwrapLpToken, getOwnerOfPositionManagerToken, decreaseLiquidityCall, burnLiquidityCall, getExactShareEnterEstimate, getShareSplit } from '../testsuite/simulator/utils/utilities.js'
+import { deployAugurConstantProductMarket, approveCash, getCashAllowance, setERC1155Approval, setupTestAccounts, getAugurConstantProductMarketRouterAddress, getMarketAddress, getPoolLiquidityBalance, getCashBalance, mintLiquidity, getNextPositionManagerToken, getExpectedLiquidity, getShareBalances, decreaseLiquidity, getReportingFee, burnLiquidity, increaseLiquidity, expectedSharesAfterSwap, enterPosition, expectedSharesNeededForSwap, exitPosition, swapExactIn, swapExactOut, getNumMarkets, getMarkets, getLpTokens, getMarketIsValid, unwrapLpToken, getOwnerOfPositionManagerToken, decreaseLiquidityCall, burnLiquidityCall, getExactShareEnterEstimate, getShareSplitEstimate, enterPositionExactShares, exitPositionExactShares } from '../testsuite/simulator/utils/utilities.js'
 import assert from 'node:assert'
 import { addressString } from '../testsuite/simulator/utils/bigint.js'
 
@@ -321,7 +321,7 @@ describe('Contract Test Suite', () => {
 		// Get estimate for exact shares
 		const desiredShares = 100000n
 		const maxDaiIn = desiredShares * numTicks
-		const estimateResults = await getExactShareEnterEstimate(participantClient1, desiredShares, true, maxDaiIn)
+		const estimateResults = await getExactShareEnterEstimate(participantClient1, desiredShares, true, maxDaiIn, 3n)
 
 		// Enter position using provided results
 		const amountInDai = estimateResults[0] * numTicks
@@ -331,6 +331,41 @@ describe('Contract Test Suite', () => {
 		assert.strictEqual(shareBalances[0], estimateResults[0], `Did not receive expected Invalid shares when purchasing Yes: Got ${shareBalances[0]}. Expected: ${desiredShares}`)
 		assert.strictEqual(shareBalances[1], 0n, `Recieved No shares when purchasing Yes`)
 		assert.strictEqual(shareBalances[2], desiredShares, `Did not recieve expected Yes shares when purchasing Yes: Got ${shareBalances[2]}. Expected: ${desiredShares}`)
+	})
+
+	test('canEnterPositionWithExactShares', async () => {
+		const client = createWriteClient(mockWindow, TEST_ADDRESSES[0], 0)
+		const participantClient1 = createWriteClient(mockWindow, TEST_ADDRESSES[1], 0)
+		await deployAugurConstantProductMarket(client)
+
+		const setsToBuy = 10000000n
+		await approveCash(client)
+		await approveCash(participantClient1)
+		const router = await getAugurConstantProductMarketRouterAddress()
+		const shareTokenAddress = addressString(SHARE_TOKEN)
+		await setERC1155Approval(client, shareTokenAddress, router, true)
+		await setERC1155Approval(participantClient1, shareTokenAddress, router, true)
+
+		await mintLiquidity(client, setsToBuy, UNIV4_MIN_TICK, UNIV4_MAX_TICK, setsToBuy, setsToBuy, YEAR_2030)
+
+		const originalDaiBalance = await getCashBalance(participantClient1)
+
+		// Enter position
+		const desiredShares = 50000n
+		const maxDaiIn = desiredShares * numTicks
+		const estimateResults = await getExactShareEnterEstimate(participantClient1, desiredShares, true, maxDaiIn, 3n)
+		const amountInDai = estimateResults[0] * numTicks
+
+		await enterPositionExactShares(participantClient1, desiredShares, true, maxDaiIn, amountInDai, 2n, YEAR_2030)
+
+		const shareBalances = await getShareBalances(participantClient1, participantClient1.account.address)
+		assert.strictEqual(shareBalances[0], estimateResults[0], `Did not receive expected Invalid shares when purchasing No: Got ${shareBalances[0]}. Expected: ${estimateResults[0]}`)
+		assert.strictEqual(shareBalances[1], 0n, `Received No shares when purchasing Yes`)
+		assert.strictEqual(shareBalances[2], desiredShares + 1n, `Did not recieve expected Yes shares when purchasing Yes: Got ${shareBalances[2]}. Expected: ${desiredShares}`)
+
+		const daiBalance = await getCashBalance(participantClient1)
+		const expectedDaiBalance = originalDaiBalance - amountInDai
+		assert.strictEqual(daiBalance, expectedDaiBalance, `Dai not sent as expected. Balance: ${daiBalance}. Expected: ${expectedDaiBalance}`)
 	})
 
 	test('canSwapNo', async () => {
@@ -407,13 +442,75 @@ describe('Contract Test Suite', () => {
 		assert.strictEqual(shareBalances[2], 0n, `Recieved Yes shares when purchasing No`)
 
 		// Swap to Yes
-		const shareSplitResults = await getShareSplit(participantClient1, expectedNoShares, false)
+		const shareSplitResults = await getShareSplitEstimate(participantClient1, expectedNoShares, expectedNoShares / 2n, false, 1n)
 
 		await swapExactIn(participantClient1, shareSplitResults[1], false)
 
 		const shareBalancesAfterSwap = await getShareBalances(participantClient1, participantClient1.account.address)
 		assert.strictEqual(shareBalancesAfterSwap[1], shareSplitResults[0], `Split did not give expected No shares`)
 		assert.strictEqual(shareBalancesAfterSwap[2], shareSplitResults[0], `Split did not give expected Yes shares`)
+	})
+
+	test('canExitWithExactShares', async () => {
+		const client = createWriteClient(mockWindow, TEST_ADDRESSES[0], 0)
+		const participantClient1 = createWriteClient(mockWindow, TEST_ADDRESSES[1], 0)
+		await deployAugurConstantProductMarket(client)
+
+		const setsToBuy = 10000000n
+		await approveCash(client)
+		await approveCash(participantClient1)
+		const router = await getAugurConstantProductMarketRouterAddress()
+		const shareTokenAddress = addressString(SHARE_TOKEN)
+		await setERC1155Approval(client, shareTokenAddress, router, true)
+		await setERC1155Approval(participantClient1, shareTokenAddress, router, true)
+
+		await mintLiquidity(client, setsToBuy, UNIV4_MIN_TICK, UNIV4_MAX_TICK, setsToBuy, setsToBuy, YEAR_2030)
+
+		const originalDaiBalance = await getCashBalance(participantClient1)
+
+		// Enter position
+		const amountInDai = 50000n
+		const baseSharesExpected = amountInDai / numTicks
+		const expectedSwapShares = await expectedSharesAfterSwap(participantClient1, true, baseSharesExpected)
+		const expectedNoShares = baseSharesExpected + expectedSwapShares
+
+		// Deadline check works
+		assert.rejects(enterPosition(participantClient1, amountInDai, false, 0n, 0n))
+
+		// minSharesOut check works
+		assert.rejects(enterPosition(participantClient1, amountInDai, false, expectedNoShares + 1n))
+
+		await enterPosition(participantClient1, amountInDai, false)
+
+		const shareBalances = await getShareBalances(participantClient1, participantClient1.account.address)
+		assert.strictEqual(shareBalances[0], baseSharesExpected, `Did not receive expected Invalid shares when purchasing No: Got ${shareBalances[0]}. Expected: ${baseSharesExpected}`)
+		assert.strictEqual(shareBalances[1], expectedNoShares, `Did not recieve expected No shares when purchasing No: Got ${shareBalances[1]}. Expected: ${expectedNoShares}`)
+		assert.strictEqual(shareBalances[2], 0n, `Recieved Yes shares when purchasing No`)
+
+		const daiBalance = await getCashBalance(participantClient1)
+		const expectedDaiBalance = originalDaiBalance - amountInDai
+		assert.strictEqual(daiBalance, expectedDaiBalance, `Dai not sent as expected. Balance: ${daiBalance}. Expected: ${expectedDaiBalance}`)
+
+		// Exit Position
+		await setERC1155Approval(participantClient1, shareTokenAddress, router, true)
+
+		const sharesToSell = expectedNoShares / 2n
+
+		const shareSplitResults = await getShareSplitEstimate(participantClient1, sharesToSell, sharesToSell / 2n, true, 2n)
+		const expectedDaiFromShares = shareSplitResults[0] * numTicks
+
+		await exitPositionExactShares(participantClient1, sharesToSell, false, shareSplitResults[1], 0n, 2n, YEAR_2030)
+
+		const reportingFee = await getReportingFee(participantClient1)
+		const daiBalanceAfterExit = await getCashBalance(participantClient1)
+		const expectedDaiFromSharesAfterReportingFee = expectedDaiFromShares - (expectedDaiFromShares / reportingFee)
+		const expectedDaiBalanceAfterExit = expectedDaiBalance + expectedDaiFromSharesAfterReportingFee
+		assert.strictEqual(daiBalanceAfterExit, expectedDaiBalanceAfterExit, `Dai not recieved as expected. Balance ${daiBalanceAfterExit}. Expected: ${expectedDaiBalanceAfterExit}`)
+
+		const shareBalancesAfterExit = await getShareBalances(participantClient1, participantClient1.account.address)
+		assert.strictEqual(shareBalancesAfterExit[0], baseSharesExpected - shareSplitResults[0], `Did not close out Invalid position when exiting No position`)
+		assert.strictEqual(shareBalancesAfterExit[1], expectedNoShares - sharesToSell, `Did not close out No position when exiting No position`)
+		assert.strictEqual(shareBalancesAfterExit[2], 0n, `Recieved Yes shares when exiting a No position`)
 	})
 
 	test('canSwapYes', async () => {

--- a/solidity/ts/testsuite/simulator/utils/utilities.ts
+++ b/solidity/ts/testsuite/simulator/utils/utilities.ts
@@ -574,6 +574,17 @@ export const decreaseLiquidity = async (client: WriteClient, positionTokenId: bi
 	})
 }
 
+export const decreaseLiquidityCall = async (client: WriteClient, positionTokenId: bigint, lpToSell: bigint, amountNoMin: bigint, amountYesMin: bigint, deadline: bigint) => {
+	const routerAddress = await getAugurConstantProductMarketRouterAddress()
+	const abi = augurConstantProductMarketContractArtifact.contracts['contracts/AugurConstantProductMarketRouter.sol'].AugurConstantProductRouter.abi
+	return await client.readContract({
+		abi: abi as Abi,
+		functionName: 'decreaseLiquidity',
+		address: routerAddress,
+		args: [augurMarketAddress, positionTokenId, lpToSell, amountNoMin, amountYesMin, deadline]
+	}) as [bigint, bigint, bigint]
+}
+
 export const burnLiquidity = async (client: WriteClient, positionTokenId: bigint, amountNoMin: bigint, amountYesMin: bigint, deadline: bigint) => {
 	const routerAddress = await getAugurConstantProductMarketRouterAddress()
 	const abi = augurConstantProductMarketContractArtifact.contracts['contracts/AugurConstantProductMarketRouter.sol'].AugurConstantProductRouter.abi
@@ -584,6 +595,17 @@ export const burnLiquidity = async (client: WriteClient, positionTokenId: bigint
 		address: routerAddress,
 		args: [augurMarketAddress, positionTokenId, amountNoMin, amountYesMin, deadline]
 	})
+}
+
+export const burnLiquidityCall = async (client: WriteClient, positionTokenId: bigint, amountNoMin: bigint, amountYesMin: bigint, deadline: bigint) => {
+	const routerAddress = await getAugurConstantProductMarketRouterAddress()
+	const abi = augurConstantProductMarketContractArtifact.contracts['contracts/AugurConstantProductMarketRouter.sol'].AugurConstantProductRouter.abi
+	return await client.readContract({
+		abi: abi as Abi,
+		functionName: 'burnLiquidity',
+		address: routerAddress,
+		args: [augurMarketAddress, positionTokenId, amountNoMin, amountYesMin, deadline]
+	}) as [bigint, bigint, bigint]
 }
 
 export const unwrapLpToken = async (client: WriteClient, positionTokenId: bigint) => {

--- a/solidity/ts/testsuite/simulator/utils/utilities.ts
+++ b/solidity/ts/testsuite/simulator/utils/utilities.ts
@@ -516,17 +516,6 @@ export const buyShares = async (client: WriteClient, sharesToBuy: bigint) => {
 	})
 }
 
-export const getShareWrappers = async (client: ReadClient) => {
-	const routerAddress = await getAugurConstantProductMarketRouterAddress()
-	const abi = augurConstantProductMarketContractArtifact.contracts['contracts/AugurConstantProductMarketRouter.sol'].AugurConstantProductRouter.abi
-	return await client.readContract({
-		abi: abi as Abi,
-		functionName: 'getShareTokenWrappers',
-		address: routerAddress,
-		args: [augurMarketAddress]
-	}) as [Address, Address]
-}
-
 export const mintLiquidity = async (client: WriteClient, sharesToBuy: bigint, tickLower: number, tickUpper: number, amountNoMax: bigint, amountYesMax: bigint, deadline: bigint) => {
 	const routerAddress = await getAugurConstantProductMarketRouterAddress()
 	const abi = augurConstantProductMarketContractArtifact.contracts['contracts/AugurConstantProductMarketRouter.sol'].AugurConstantProductRouter.abi
@@ -632,6 +621,29 @@ export const enterPosition = async (client: WriteClient, amountInDai: bigint, bu
 	})
 }
 
+export const enterPositionExactShares = async (client: WriteClient, exactShares: bigint, buyYes: boolean, maxDaiIn: bigint, estimatedDaiIn: bigint, maxIterations: bigint = 10n, deadline = YEAR_2030) => {
+	const routerAddress = await getAugurConstantProductMarketRouterAddress()
+	const abi = augurConstantProductMarketContractArtifact.contracts['contracts/AugurConstantProductMarketRouter.sol'].AugurConstantProductRouter.abi
+	return await client.writeContract({
+		chain: mainnet,
+		abi: abi as Abi,
+		functionName: 'enterPositionExactShares',
+		address: routerAddress,
+		args: [augurMarketAddress, exactShares, buyYes, maxDaiIn, estimatedDaiIn, maxIterations, deadline]
+	})
+}
+
+export const enterPositionExactSharesGasEstimate = async (client: WriteClient, exactShares: bigint, buyYes: boolean, maxDaiIn: bigint, estimatedDaiIn: bigint, maxIterations: bigint = 10n, deadline = YEAR_2030) => {
+	const routerAddress = await getAugurConstantProductMarketRouterAddress()
+	const abi = augurConstantProductMarketContractArtifact.contracts['contracts/AugurConstantProductMarketRouter.sol'].AugurConstantProductRouter.abi
+	return await client.estimateContractGas({
+		abi: abi as Abi,
+		functionName: 'enterPositionExactShares',
+		address: routerAddress,
+		args: [augurMarketAddress, exactShares, buyYes, maxDaiIn, estimatedDaiIn, maxIterations, deadline]
+	})
+}
+
 export const approveToken = async (client: WriteClient, tokenAddress: Address, spenderAddress: Address) => {
 	const amount = 1000000000000000000000000000000000n
 	return await client.writeContract({
@@ -662,6 +674,18 @@ export const exitPosition = async (client: WriteClient, daiToBuy: bigint, maxSha
 		functionName: 'exitPosition',
 		address: routerAddress,
 		args: [augurMarketAddress, daiToBuy, maxSharesIn, deadline]
+	})
+}
+
+export const exitPositionExactShares = async (client: WriteClient, sharesToSell: bigint, sellyes: boolean, swapEstimate: bigint, minDaiOut: bigint, maxIterations: bigint, deadline = YEAR_2030) => {
+	const routerAddress = await getAugurConstantProductMarketRouterAddress()
+	const abi = augurConstantProductMarketContractArtifact.contracts['contracts/AugurConstantProductMarketRouter.sol'].AugurConstantProductRouter.abi
+	return await client.writeContract({
+		chain: mainnet,
+		abi: abi as Abi,
+		functionName: 'exitPositionExactShares',
+		address: routerAddress,
+		args: [augurMarketAddress, sharesToSell, sellyes, swapEstimate, minDaiOut, maxIterations, deadline]
 	})
 }
 
@@ -713,24 +737,46 @@ export const expectedSharesNeededForSwap = async (client: ReadClient, swapYes: b
 	return results[0]
 }
 
-export const getExactShareEnterEstimate = async (client: ReadClient, exactShares: bigint, buyYes: boolean, maxDaiIn: bigint) => {
+export const getExactShareEnterEstimate = async (client: ReadClient, exactShares: bigint, buyYes: boolean, maxDaiIn: bigint, maxIterations: bigint = 10n) => {
 	const routerAddress = await getAugurConstantProductMarketRouterAddress()
 	const abi = augurConstantProductMarketContractArtifact.contracts['contracts/AugurConstantProductMarketRouter.sol'].AugurConstantProductRouter.abi
 	return await client.readContract({
 		abi: abi as Abi,
 		functionName: 'getExactShareEnterEstimate',
 		address: routerAddress,
-		args: [augurMarketAddress, exactShares, buyYes, maxDaiIn]
+		args: [augurMarketAddress, exactShares, buyYes, maxDaiIn, maxIterations]
 	}) as [bigint, bigint]
 }
 
-export const getShareSplit = async (client: ReadClient, sharesToSwap: bigint, buyYes: boolean) => {
+export const getExactShareEnterEstimateGas = async (client: ReadClient, exactShares: bigint, buyYes: boolean, estimatedDaiIn: bigint, maxIterations: bigint = 10n) => {
+	const routerAddress = await getAugurConstantProductMarketRouterAddress()
+	const abi = augurConstantProductMarketContractArtifact.contracts['contracts/AugurConstantProductMarketRouter.sol'].AugurConstantProductRouter.abi
+	return await client.estimateContractGas({
+		abi: abi as Abi,
+		functionName: 'getExactShareEnterEstimate',
+		address: routerAddress,
+		args: [augurMarketAddress, exactShares, buyYes, estimatedDaiIn, maxIterations]
+	})
+}
+
+export const getShareSplitEstimate = async (client: ReadClient, sharesToSwap: bigint, swapEstimate: bigint, buyYes: boolean, maxIterations: bigint = 10n) => {
 	const routerAddress = await getAugurConstantProductMarketRouterAddress()
 	const abi = augurConstantProductMarketContractArtifact.contracts['contracts/AugurConstantProductMarketRouter.sol'].AugurConstantProductRouter.abi
 	return await client.readContract({
 		abi: abi as Abi,
-		functionName: 'getShareSplit',
+		functionName: 'getShareSplitEstimate',
 		address: routerAddress,
-		args: [augurMarketAddress, sharesToSwap, buyYes]
+		args: [augurMarketAddress, sharesToSwap, swapEstimate, buyYes, maxIterations]
 	}) as [bigint, bigint]
+}
+
+export const getShareSplitEstimateGas = async (client: WriteClient, sharesToSwap: bigint, swapEstimate: bigint, buyYes: boolean, maxIterations: bigint = 10n) => {
+	const routerAddress = await getAugurConstantProductMarketRouterAddress()
+	const abi = augurConstantProductMarketContractArtifact.contracts['contracts/AugurConstantProductMarketRouter.sol'].AugurConstantProductRouter.abi
+	return await client.estimateContractGas({
+		abi: abi as Abi,
+		functionName: 'getShareSplitEstimate',
+		address: routerAddress,
+		args: [augurMarketAddress, sharesToSwap, swapEstimate, buyYes, maxIterations]
+	})
 }

--- a/solidity/ts/testsuite/simulator/utils/utilities.ts
+++ b/solidity/ts/testsuite/simulator/utils/utilities.ts
@@ -712,3 +712,25 @@ export const expectedSharesNeededForSwap = async (client: ReadClient, swapYes: b
 	}) as [bigint, bigint]
 	return results[0]
 }
+
+export const getExactShareEnterEstimate = async (client: ReadClient, exactShares: bigint, buyYes: boolean, maxDaiIn: bigint) => {
+	const routerAddress = await getAugurConstantProductMarketRouterAddress()
+	const abi = augurConstantProductMarketContractArtifact.contracts['contracts/AugurConstantProductMarketRouter.sol'].AugurConstantProductRouter.abi
+	return await client.readContract({
+		abi: abi as Abi,
+		functionName: 'getExactShareEnterEstimate',
+		address: routerAddress,
+		args: [augurMarketAddress, exactShares, buyYes, maxDaiIn]
+	}) as [bigint, bigint]
+}
+
+export const getShareSplit = async (client: ReadClient, sharesToSwap: bigint, buyYes: boolean) => {
+	const routerAddress = await getAugurConstantProductMarketRouterAddress()
+	const abi = augurConstantProductMarketContractArtifact.contracts['contracts/AugurConstantProductMarketRouter.sol'].AugurConstantProductRouter.abi
+	return await client.readContract({
+		abi: abi as Abi,
+		functionName: 'getShareSplit',
+		address: routerAddress,
+		args: [augurMarketAddress, sharesToSwap, buyYes]
+	}) as [bigint, bigint]
+}


### PR DESCRIPTION
Reduction in liquidity functions now return `(uint256 completeSetsToSell, uint256 noShares, uint256 yesShares)`. completeSetsToSell can be used to derive the Invalid shares token from the user and the dai they will receive, while the share values are excess shares they'll receive.

`getExactShareEnterEstimate` will return the setsToBuy and the resultingShares. The expectation is that the resultingShares will be the desired share amount but if not another call will be required to find the correct setsToBuyValue.

`getShareSplit` returns the shareBalance of the shares being swapped to and the amountToSwap. If the initial shares - amountToSwap is not == shares then the function ran out of gas before finding the desired swap.